### PR TITLE
Typesafe effects for acquiring resources

### DIFF
--- a/examples/src/HandleResource.hs
+++ b/examples/src/HandleResource.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE DataKinds                          #-}
+{-# LANGUAGE FlexibleContexts                   #-}
+{-# LANGUAGE FlexibleInstances                  #-}
+{-# LANGUAGE MultiParamTypeClasses              #-}
+{-# LANGUAGE RankNTypes                         #-}
+{-# LANGUAGE ScopedTypeVariables                #-}
+{-# LANGUAGE TypeApplications                   #-}
+{-# LANGUAGE TypeFamilies                       #-}
+{-# LANGUAGE TypeOperators                      #-}
+{-# OPTIONS_GHC -fno-warn-orphans               #-}
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
+
+module HandleResource where
+
+import           Control.Exception (SomeException, catch)
+import           Control.Monad.Freer
+import           Control.Monad.Freer.Exception (Exc (..), throwError)
+import           Control.Monad.Freer.Internal (prj)
+import           Control.Monad.Freer.Resource
+import           System.IO (Handle)
+import qualified System.IO as IO
+
+------------------------------------------------------------------------------
+-- | Example region for acquiring file 'Handle's.
+fileHandleRegion :: forall r a
+                  . ( Member IO r
+                    , SafeForRegion Handle r
+                    , Member (Exc SomeException) r
+                    )
+                 => Region Handle r a
+                 -> Eff r a
+fileHandleRegion = handleRegionRelay (send . uncurry IO.openFile) (send . close) handler
+  where
+    close :: Handle -> IO ()
+    close fh = do
+      catch (IO.hClose fh) (\(_ :: SomeException) -> return ())
+
+    handler releaseAll ignore u =
+      case prj u of
+        Just (Exc e) -> releaseAll >> throwError (e :: SomeException)
+        Nothing      -> ignore u
+
+type instance ResourceCtor Handle = (FilePath, IO.IOMode)
+
+instance SafeForRegion Handle r => SafeForRegion Handle (Exc SomeException ': r)
+instance SafeForRegion Handle '[IO]
+
+openFile :: forall r s
+         . ( s ~ Ancestor 0 r
+           , Member (RegionEff Handle s) r
+           )
+        => FilePath
+        -> IO.IOMode
+        -> Eff r (Resource Handle s)
+openFile = curry $ acquire @Handle
+

--- a/examples/src/HandleResource.hs
+++ b/examples/src/HandleResource.hs
@@ -16,7 +16,7 @@ import           Control.Exception (SomeException)
 import           Control.Monad.Freer (Member, Eff ())
 import           Control.Monad.Freer.Exception (Exc (..))
 import           Control.Monad.Freer.SafeIO (SIO, safeIO)
-import           Control.Monad.Freer.Resource (handleRegionRelay, catchSafeIOExcs, Ancestor, ResourceCtor, SafeForRegion, Resource, RegionEff, Region, unsafeWithResource, acquire)
+import           Control.Monad.Freer.Region (handleRegionRelay, catchSafeIOExcs, Ancestor, ResourceCtor, SafeForRegion, Resource, RegionEff, Region, unsafeWithResource, acquire)
 import           System.IO (Handle)
 import qualified System.IO as IO
 

--- a/examples/src/Region.hs
+++ b/examples/src/Region.hs
@@ -15,7 +15,7 @@ module Region where
 
 import           Control.Exception
 import           Control.Monad.Freer
-import           Control.Monad.Freer.Resource
+import           Control.Monad.Freer.Region
 import           Control.Monad.Freer.SafeIO
 import           Control.Monad.Freer.Exception (Exc (..))
 

--- a/examples/src/Region.hs
+++ b/examples/src/Region.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE DataKinds                          #-}
+{-# LANGUAGE FlexibleContexts                   #-}
+{-# LANGUAGE FlexibleInstances                  #-}
+{-# LANGUAGE MultiParamTypeClasses              #-}
+{-# LANGUAGE RankNTypes                         #-}
+{-# LANGUAGE ScopedTypeVariables                #-}
+{-# LANGUAGE TypeApplications                   #-}
+{-# LANGUAGE TypeFamilies                       #-}
+{-# LANGUAGE TypeOperators                      #-}
+{-# LANGUAGE UndecidableInstances               #-}
+{-# OPTIONS_GHC -fno-warn-orphans               #-}
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
+
+module Region where
+
+import           Control.Exception
+import           Control.Monad.Freer
+import           Control.Monad.Freer.Resource
+import           Control.Monad.Freer.SafeIO
+import           Control.Monad.Freer.Exception (Exc (..))
+
+data Crazy = Crazy deriving Eq
+
+instance SafeForRegion Crazy '[SIO, Exc SomeException]
+type instance ResourceCtor Crazy = ()
+
+crazyRegion :: forall r a
+             . ( SafeForRegion Crazy r
+               , Member SIO r
+               , Member (Exc SomeException) r
+               )
+            => Region Crazy r a
+            -> Eff r a
+crazyRegion = handleRegionRelay mkCrazy rmCrazy catchSafeIOExcs
+  where
+    mkCrazy _ = do
+      safeIO $ putStrLn "acquiring crazy"
+      return Crazy
+
+    rmCrazy _ = do
+      safeIO $ putStrLn "unallocating crazy"
+
+
+goCrazy :: forall r s
+         . ( s ~ Ancestor 0 r
+           , Member (RegionEff Crazy s) r
+           )
+        => Eff r (Resource Crazy s)
+goCrazy = acquire @Crazy ()
+
+------------------------------------------------------------------------------
+
+don'tReleaseOnReturn :: IO ()
+don'tReleaseOnReturn = runSafeIO $ do
+  crazyRegion $ do
+    _ <- goCrazy
+    _ <- return True
+    safeIO $ putStrLn "we still have a crazy in scope :)"
+
+{-
+acquiring crazy
+we still have a crazy in scope :)
+unallocating crazy
+-}
+
+runFinalizerOnError :: IO ()
+runFinalizerOnError = runSafeIO $ do
+  crazyRegion $ do
+    _ <- goCrazy
+    _ <- safeIO $ throwIO Overflow
+    safeIO $ putStrLn "this doesn't get run"
+
+{-
+acquiring crazy
+unallocating crazy
+*** Exception: arithmetic overflow
+-}

--- a/freer-effects.cabal
+++ b/freer-effects.cabal
@@ -55,13 +55,13 @@ flag test-hlint
 library
   hs-source-dirs:
       src
-  ghc-options: -Wall -fwarn-tabs -fwarn-implicit-prelude
+  ghc-options: -Wall -fwarn-tabs
   build-depends:
       base >=4.7 && <5
   if flag(pedantic)
     ghc-options: -Werror
   if impl(ghc >=8)
-    ghc-options: -Wredundant-constraints -Wmissing-import-lists
+    ghc-options: -Wredundant-constraints
   if impl(ghc >=7.10)
     cpp-options: -DDEPRECATED_LANGUAGE_OVERLAPPING_INSTANCES
   exposed-modules:
@@ -81,6 +81,7 @@ library
       Data.OpenUnion
       Data.OpenUnion.Internal
   other-modules:
+      Control.Monad.Freer.Resource
       Paths_freer_effects
   default-language: Haskell2010
 
@@ -88,20 +89,23 @@ executable freer-examples
   main-is: Main.hs
   hs-source-dirs:
       examples/src
-  ghc-options: -Wall -fwarn-tabs -fwarn-implicit-prelude
+  ghc-options: -Wall -fwarn-tabs
   build-depends:
       base >=4.7 && <5
     , freer-effects
+    , exceptions
   if flag(pedantic)
     ghc-options: -Werror
   if impl(ghc >=8)
-    ghc-options: -Wredundant-constraints -Wmissing-import-lists
+    ghc-options: -Wredundant-constraints
   other-modules:
       Capitalize
       Console
       Coroutine
       Cut
       Fresh
+      HandleResource
+      Region
       Trace
   default-language: Haskell2010
 
@@ -110,13 +114,13 @@ test-suite hlint
   main-is: hlint.hs
   hs-source-dirs:
       tests
-  ghc-options: -Wall -fwarn-tabs -fwarn-implicit-prelude -threaded -with-rtsopts=-N
+  ghc-options: -Wall -fwarn-tabs -threaded -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
   if flag(pedantic)
     ghc-options: -Werror
   if impl(ghc >=8)
-    ghc-options: -Wredundant-constraints -Wmissing-import-lists
+    ghc-options: -Wredundant-constraints
   if flag(test-hlint)
     build-depends:
         hlint >=1.9
@@ -130,7 +134,7 @@ test-suite unit
   main-is: Tests.hs
   hs-source-dirs:
       tests
-  ghc-options: -Wall -fwarn-tabs -fwarn-implicit-prelude
+  ghc-options: -Wall -fwarn-tabs
   build-depends:
       base >=4.7 && <5
     , QuickCheck
@@ -141,7 +145,7 @@ test-suite unit
   if flag(pedantic)
     ghc-options: -Werror
   if impl(ghc >=8)
-    ghc-options: -Wredundant-constraints -Wmissing-import-lists
+    ghc-options: -Wredundant-constraints
   other-modules:
       Tests.Coroutine
       Tests.Exception
@@ -157,7 +161,7 @@ benchmark core
   main-is: Core.hs
   hs-source-dirs:
       bench
-  ghc-options: -Wall -fwarn-tabs -fwarn-implicit-prelude -O2
+  ghc-options: -Wall -fwarn-tabs -O2
   build-depends:
       base >=4.7 && <5
     , criterion
@@ -168,5 +172,5 @@ benchmark core
   if flag(pedantic)
     ghc-options: -Werror
   if impl(ghc >=8)
-    ghc-options: -Wredundant-constraints -Wmissing-import-lists
+    ghc-options: -Wredundant-constraints
   default-language: Haskell2010

--- a/freer-effects.cabal
+++ b/freer-effects.cabal
@@ -55,13 +55,13 @@ flag test-hlint
 library
   hs-source-dirs:
       src
-  ghc-options: -Wall -fwarn-tabs
+  ghc-options: -Wall -fwarn-tabs -fwarn-implicit-prelude
   build-depends:
       base >=4.7 && <5
   if flag(pedantic)
     ghc-options: -Werror
   if impl(ghc >=8)
-    ghc-options: -Wredundant-constraints
+    ghc-options: -Wredundant-constraints -Wmissing-import-lists
   if impl(ghc >=7.10)
     cpp-options: -DDEPRECATED_LANGUAGE_OVERLAPPING_INSTANCES
   exposed-modules:
@@ -73,6 +73,8 @@ library
       Control.Monad.Freer.Internal
       Control.Monad.Freer.NonDet
       Control.Monad.Freer.Reader
+      Control.Monad.Freer.Region
+      Control.Monad.Freer.SafeIO
       Control.Monad.Freer.State
       Control.Monad.Freer.StateRW
       Control.Monad.Freer.Trace
@@ -81,8 +83,6 @@ library
       Data.OpenUnion
       Data.OpenUnion.Internal
   other-modules:
-      Control.Monad.Freer.Resource
-      Control.Monad.Freer.SafeIO
       Paths_freer_effects
   default-language: Haskell2010
 
@@ -90,14 +90,14 @@ executable freer-examples
   main-is: Main.hs
   hs-source-dirs:
       examples/src
-  ghc-options: -Wall -fwarn-tabs
+  ghc-options: -Wall -fwarn-tabs -fwarn-implicit-prelude
   build-depends:
       base >=4.7 && <5
     , freer-effects
   if flag(pedantic)
     ghc-options: -Werror
   if impl(ghc >=8)
-    ghc-options: -Wredundant-constraints
+    ghc-options: -Wredundant-constraints -Wmissing-import-lists
   other-modules:
       Capitalize
       Console
@@ -114,13 +114,13 @@ test-suite hlint
   main-is: hlint.hs
   hs-source-dirs:
       tests
-  ghc-options: -Wall -fwarn-tabs -threaded -with-rtsopts=-N
+  ghc-options: -Wall -fwarn-tabs -fwarn-implicit-prelude -threaded -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
   if flag(pedantic)
     ghc-options: -Werror
   if impl(ghc >=8)
-    ghc-options: -Wredundant-constraints
+    ghc-options: -Wredundant-constraints -Wmissing-import-lists
   if flag(test-hlint)
     build-depends:
         hlint >=1.9
@@ -134,7 +134,7 @@ test-suite unit
   main-is: Tests.hs
   hs-source-dirs:
       tests
-  ghc-options: -Wall -fwarn-tabs
+  ghc-options: -Wall -fwarn-tabs -fwarn-implicit-prelude
   build-depends:
       base >=4.7 && <5
     , QuickCheck
@@ -145,7 +145,7 @@ test-suite unit
   if flag(pedantic)
     ghc-options: -Werror
   if impl(ghc >=8)
-    ghc-options: -Wredundant-constraints
+    ghc-options: -Wredundant-constraints -Wmissing-import-lists
   other-modules:
       Tests.Coroutine
       Tests.Exception
@@ -161,7 +161,7 @@ benchmark core
   main-is: Core.hs
   hs-source-dirs:
       bench
-  ghc-options: -Wall -fwarn-tabs -O2
+  ghc-options: -Wall -fwarn-tabs -fwarn-implicit-prelude -O2
   build-depends:
       base >=4.7 && <5
     , criterion
@@ -172,5 +172,5 @@ benchmark core
   if flag(pedantic)
     ghc-options: -Werror
   if impl(ghc >=8)
-    ghc-options: -Wredundant-constraints
+    ghc-options: -Wredundant-constraints -Wmissing-import-lists
   default-language: Haskell2010

--- a/freer-effects.cabal
+++ b/freer-effects.cabal
@@ -82,6 +82,7 @@ library
       Data.OpenUnion.Internal
   other-modules:
       Control.Monad.Freer.Resource
+      Control.Monad.Freer.SafeIO
       Paths_freer_effects
   default-language: Haskell2010
 
@@ -93,7 +94,6 @@ executable freer-examples
   build-depends:
       base >=4.7 && <5
     , freer-effects
-    , exceptions
   if flag(pedantic)
     ghc-options: -Werror
   if impl(ghc >=8)

--- a/package.yaml
+++ b/package.yaml
@@ -59,9 +59,6 @@ ghc-options:
 
 dependencies:
   - base >=4.7 && <5
-  - monad-control
-  - transformers-base
-  - lifted-base
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -52,10 +52,12 @@ when:
       # Introduced in GHC 8.
       - -Wredundant-constraints
       # Older Cabal generates warnings with its Paths_* module.
+      - -Wmissing-import-lists
 
 ghc-options:
   - -Wall
   - -fwarn-tabs
+  - -fwarn-implicit-prelude
 
 dependencies:
   - base >=4.7 && <5
@@ -71,6 +73,8 @@ library:
     - Control.Monad.Freer.Internal
     - Control.Monad.Freer.NonDet
     - Control.Monad.Freer.Reader
+    - Control.Monad.Freer.Region
+    - Control.Monad.Freer.SafeIO
     - Control.Monad.Freer.State
     - Control.Monad.Freer.StateRW
     - Control.Monad.Freer.Trace

--- a/package.yaml
+++ b/package.yaml
@@ -52,15 +52,16 @@ when:
       # Introduced in GHC 8.
       - -Wredundant-constraints
       # Older Cabal generates warnings with its Paths_* module.
-      - -Wmissing-import-lists
 
 ghc-options:
   - -Wall
   - -fwarn-tabs
-  - -fwarn-implicit-prelude
 
 dependencies:
   - base >=4.7 && <5
+  - monad-control
+  - transformers-base
+  - lifted-base
 
 library:
   source-dirs: src

--- a/src/Control/Monad/Freer/Internal.hs
+++ b/src/Control/Monad/Freer/Internal.hs
@@ -171,6 +171,10 @@ run _       = error "Internal:run - This (E) should never happen"
 -- | Runs a set of Effects. Requires that all effects are consumed, except for
 -- a single effect known to be a monad. The value returned is a computation in
 -- that monad. This is useful for plugging in traditional transformer stacks.
+--
+-- Note that if the monad is 'IO', you should consider using
+-- 'Control.Monad.Freer.SafeIO.runSafeIO' instead, as it provides the ability
+-- to catch and recover from IO exceptions in 'Eff' code.
 runM :: Monad m => Eff '[m] a -> m a
 runM (Val x) = return x
 runM (E u q) = case extract u of

--- a/src/Control/Monad/Freer/Region.hs
+++ b/src/Control/Monad/Freer/Region.hs
@@ -13,7 +13,7 @@
 {-# LANGUAGE UndecidableInstances               #-}
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
-module Control.Monad.Freer.Resource
+module Control.Monad.Freer.Region
   ( SafeForRegion
   , Resource ()
   , Region

--- a/src/Control/Monad/Freer/Resource.hs
+++ b/src/Control/Monad/Freer/Resource.hs
@@ -21,6 +21,7 @@ module Control.Monad.Freer.Resource
   , catchNothing
   , acquire
   , acquire'
+  , handleRegionRelay
   , fileHandleRegion
   , give
   , thisRegion

--- a/src/Control/Monad/Freer/Resource.hs
+++ b/src/Control/Monad/Freer/Resource.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE ConstraintKinds                    #-}
+{-# LANGUAGE DataKinds                          #-}
+{-# LANGUAGE FlexibleContexts                   #-}
+{-# LANGUAGE FlexibleInstances                  #-}
+{-# LANGUAGE GADTs                              #-}
+{-# LANGUAGE PolyKinds                          #-}
+{-# LANGUAGE RankNTypes                         #-}
+{-# LANGUAGE ScopedTypeVariables                #-}
+{-# LANGUAGE TypeFamilies                       #-}
+{-# LANGUAGE TypeOperators                      #-}
+{-# LANGUAGE UndecidableInstances               #-}
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
+
+module Control.Monad.Freer.Resource where
+
+import Control.Exception
+import Control.Monad.Freer
+import Control.Monad.Freer.Internal
+import Control.Monad.Freer.Exception
+import GHC.TypeLits (Nat, type (+), type (-), type (<=))
+import Data.Proxy
+import Data.List (delete)
+import System.IO
+
+data SIO a where
+  DoIO :: IO a -> SIO (Either SomeException a)
+
+type SMonadIO r = (Member SIO r, Member (Exc SomeException) r)
+
+lIO :: SMonadIO r => IO a -> Eff r a
+lIO m = send (DoIO m) >>= either throwError return
+
+topSIO :: Eff '[SIO, Exc SomeException] w -> IO w
+topSIO (Val x) = return x
+topSIO (E u q) | Just (DoIO m) <- prj u = try m >>= topSIO . qApp q
+topSIO (E u _) | Just (Exc e)  <- prj u = throw (e :: SomeException)
+topSIO (E _ _) = error "cannot happen"
+
+
+class SafeForRegion (r :: [* -> *])
+instance SafeForRegion '[]
+instance SafeForRegion r => SafeForRegion (SIO ': r)
+instance SafeForRegion r => SafeForRegion (Exc SomeException ': r)
+instance SafeForRegion r => SafeForRegion (RegionEff s ': r)
+-- instance SafeForRegion r => SafeForRegion (Reader a ': r)
+-- instance SafeForRegion r => SafeForRegion (State a ': r)
+
+newtype SHandle s = SHandle Handle
+
+
+-- Data constructors are not exported
+data RegionEff s a where
+  RENew :: FilePath -> IOMode -> RegionEff s (SHandle s)
+  -- Used for duplicating regions
+  REForget  :: SHandle s -> RegionEff s ()
+  REAcquire :: SHandle s' -> RegionEff s (SHandle s)
+
+type family Ancestor (n::Nat) (lst :: [* -> *]) :: * where
+  Ancestor 0 (RegionEff s ': lst)     = s
+  Ancestor n (RegionEff s ': lst)     = Ancestor (n-1) lst
+  Ancestor n  (t ': lst)              = Ancestor n lst
+
+newSHandle :: (SMonadIO r, s ~ Ancestor 0 r, Member (RegionEff s) r) => FilePath -> IOMode -> Eff r (SHandle s)
+newSHandle = newSHandle' (Proxy::Proxy 0)
+
+newSHandle' :: (SMonadIO r, s ~ Ancestor n r, Member (RegionEff s) r) => Proxy n -> FilePath -> IOMode -> Eff r (SHandle s)
+newSHandle' _ fname fmode = send (RENew fname fmode)
+
+type family Length (lst :: [* -> *]) :: Nat where
+  Length '[] = 0
+  Length (RegionEff x ': t) = 1 + (Length t)
+  Length (h ': t) = Length t
+
+data L (n::Nat) k
+
+
+newRgn :: forall r a. SMonadIO r =>
+          (forall s. Eff (RegionEff (L (Length r) s) ': r) a) -> Eff r a
+newRgn m = loop [] m
+ where
+   loop :: [Handle] -> Eff (RegionEff (L (Length r) s) ': r) a -> Eff r a
+   loop fhs (Val x) = close_fhs fhs >> return x
+   loop fhs (E u q)  = case decomp u of
+     Right (RENew fname fmode) -> do
+       fh <- lIO $ openFile fname fmode -- may raise exc
+       k (fh:fhs) (SHandle fh)
+     Right (REForget (SHandle fh)) -> k (delete fh fhs) ()
+     Right (REAcquire (SHandle fh)) ->
+       k (if fh `elem` fhs then fhs else fh:fhs) (SHandle fh)
+     Left  u' -> case prj u' of
+       Just (Exc e) -> close_fhs fhs >> throwError (e::SomeException)
+       Nothing      -> E u' (tsingleton (k fhs))
+    where k s = qComp q (loop s)
+
+       -- Close all file handles of a region
+   close_fhs []  = return ()
+   close_fhs fhs = send (DoIO (mapM_ close fhs)) >> return ()
+   close :: Handle -> IO ()
+   close fh = do
+    hPutStrLn stderr $ "Closing " ++ show fh
+    catch (hClose fh) (\(e::SomeException) ->
+                        hPutStrLn stderr ("Error on close: " ++ show e))
+
+type ActiveRegion s r = (Member (RegionEff s) r, SMonadIO r)
+
+shDup :: (ActiveRegion s r, ActiveRegion s' r,
+         s' ~ Ancestor n r,
+         s ~ (L n1 e1), s' ~ (L n2 e2), n2 <= n1) => Proxy n -> SHandle s -> Eff r (SHandle s')
+shDup _ h =
+  send (REForget h) >> send (REAcquire h)
+
+

--- a/src/Control/Monad/Freer/Resource.hs
+++ b/src/Control/Monad/Freer/Resource.hs
@@ -33,7 +33,7 @@ module Control.Monad.Freer.Resource
   ) where
 
 import Control.Exception (SomeException)
-import Control.Monad.Freer
+import Control.Monad.Freer (Member, send)
 import Control.Monad.Freer.Internal (Union, Eff (..), qComp, tsingleton, decomp, prj)
 import Control.Monad.Freer.Exception (Exc (..), throwError)
 import Data.Bool (bool)
@@ -61,9 +61,7 @@ newtype Resource res s = Resource res
 -- | Helper function to allow library writers to work with 'Resource's. End
 -- users must never use this function, as its misuse can leak resources from
 -- their scoping regions.
---
--- TODO(sandy): how can we existentialize 'res' so it can't escape?
-unsafeWithResource :: Resource res s -> (forall b. (res ~ b) => b -> a) -> a
+unsafeWithResource :: Resource res s -> (res -> a) -> a
 unsafeWithResource (Resource r) f = f r
 
 

--- a/src/Control/Monad/Freer/SafeIO.hs
+++ b/src/Control/Monad/Freer/SafeIO.hs
@@ -9,10 +9,10 @@ module Control.Monad.Freer.SafeIO
   , safeIO
   ) where
 
-import Control.Monad.Freer
-import Control.Monad.Freer.Internal
-import Control.Monad.Freer.Exception
-import Control.Exception
+import Control.Monad.Freer (send, Member)
+import Control.Monad.Freer.Internal (qApp, prj, Eff (..))
+import Control.Monad.Freer.Exception (Exc (..), throwError)
+import Control.Exception (throw, SomeException, try)
 
 
 ------------------------------------------------------------------------------

--- a/src/Control/Monad/Freer/SafeIO.hs
+++ b/src/Control/Monad/Freer/SafeIO.hs
@@ -3,7 +3,11 @@
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Control.Monad.Freer.SafeIO where
+module Control.Monad.Freer.SafeIO
+  ( SIO ()
+  , runSafeIO
+  , safeIO
+  ) where
 
 import Control.Monad.Freer
 import Control.Monad.Freer.Internal
@@ -11,15 +15,25 @@ import Control.Monad.Freer.Exception
 import Control.Exception
 
 
+------------------------------------------------------------------------------
+-- | Safe IO effect.
 data SIO a where
   DoIO :: IO a -> SIO (Either SomeException a)
 
+
+------------------------------------------------------------------------------
+-- | Interprets 'SIO' into 'IO'. There is an @Exc SomeException@ *underneath*
+-- the safe IO effect here to ensure we always have it in our effect stack. Any
+-- exceptions left unhandled in this effect will be rethrown in IO.
 runSafeIO :: Eff '[SIO, Exc SomeException] w -> IO w
 runSafeIO (Val x) = return x
 runSafeIO (E u q) | Just (DoIO m) <- prj u = try m >>= runSafeIO . qApp q
 runSafeIO (E u _) | Just (Exc e)  <- prj u = throw (e :: SomeException)
 runSafeIO (E _ _) = error "can't happen"
 
+
+------------------------------------------------------------------------------
+-- | Lift an 'IO' action to the 'SIO' effect.
 safeIO :: (Member SIO r, Member (Exc SomeException) r) => IO a -> Eff r a
 safeIO io = either throwError return =<< send (DoIO io)
 

--- a/src/Control/Monad/Freer/SafeIO.hs
+++ b/src/Control/Monad/Freer/SafeIO.hs
@@ -13,7 +13,7 @@ import Control.Monad.Freer (send, Member)
 import Control.Monad.Freer.Internal (qApp, prj, Eff (..))
 import Control.Monad.Freer.Exception (Exc (..), throwError)
 import Control.Exception (throw, SomeException, try)
-
+import Prelude (Maybe (Just), IO, Either (), (>>=), return, (=<<), either, error, (.))
 
 ------------------------------------------------------------------------------
 -- | Safe IO effect.

--- a/src/Control/Monad/Freer/SafeIO.hs
+++ b/src/Control/Monad/Freer/SafeIO.hs
@@ -18,7 +18,7 @@ import Control.Exception
 ------------------------------------------------------------------------------
 -- | Safe IO effect.
 data SIO a where
-  DoIO :: IO a -> SIO (Either SomeException a)
+  Safely :: IO a -> SIO (Either SomeException a)
 
 
 ------------------------------------------------------------------------------
@@ -27,13 +27,13 @@ data SIO a where
 -- exceptions left unhandled in this effect will be rethrown in IO.
 runSafeIO :: Eff '[SIO, Exc SomeException] w -> IO w
 runSafeIO (Val x) = return x
-runSafeIO (E u q) | Just (DoIO m) <- prj u = try m >>= runSafeIO . qApp q
-runSafeIO (E u _) | Just (Exc e)  <- prj u = throw (e :: SomeException)
+runSafeIO (E u q) | Just (Safely m) <- prj u = try m >>= runSafeIO . qApp q
+runSafeIO (E u _) | Just (Exc e)    <- prj u = throw (e :: SomeException)
 runSafeIO (E _ _) = error "can't happen"
 
 
 ------------------------------------------------------------------------------
 -- | Lift an 'IO' action to the 'SIO' effect.
 safeIO :: (Member SIO r, Member (Exc SomeException) r) => IO a -> Eff r a
-safeIO io = either throwError return =<< send (DoIO io)
+safeIO io = either throwError return =<< send (Safely io)
 

--- a/src/Control/Monad/Freer/SafeIO.hs
+++ b/src/Control/Monad/Freer/SafeIO.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Control.Monad.Freer.SafeIO where
+
+import Control.Monad.Freer
+import Control.Monad.Freer.Internal
+import Control.Monad.Freer.Exception
+import Control.Exception
+
+
+data SIO a where
+  DoIO :: IO a -> SIO (Either SomeException a)
+
+runSafeIO :: Eff '[SIO, Exc SomeException] w -> IO w
+runSafeIO (Val x) = return x
+runSafeIO (E u q) | Just (DoIO m) <- prj u = try m >>= runSafeIO . qApp q
+runSafeIO (E u _) | Just (Exc e)  <- prj u = throw (e :: SomeException)
+runSafeIO (E _ _) = error "can't happen"
+
+safeIO :: (Member SIO r, Member (Exc SomeException) r) => IO a -> Eff r a
+safeIO io = either throwError return =<< send (DoIO io)
+


### PR DESCRIPTION
This PR is an implementation and subsequent generalization of the `SHandle` region construction from the paper 'Freer Monads, More Extensible Effects'. 

It provides a function `handleRegionRelay` which can be used to implement regions which are capable of acquiring resources, and automatically releasing them at the end of its scope. The type system guarantees that these resources cannot escape their scope, and can also limit which effects are allowed to be available in the same scope (non-determinism, for example, would break the invariants provided by regions, so we can exclude them by this mechanism). Due to this closed world, `handleRegionRelay` can deal with short-circuiting interpreters by intercepting their requests before the short-circuiting one would.

I wish I had thought of most of this stuff :)